### PR TITLE
Fix: Strip ANSI escape codes from opaque-types compiler output

### DIFF
--- a/buildrs/opaque_types_generator.rs
+++ b/buildrs/opaque_types_generator.rs
@@ -16,6 +16,10 @@ pub fn generate_opaque_types() {
         // The first error may only be preceded by a `\r`,
         // so this ensures it will be included in `total_error_count`
         .replace('\r', "\n");
+    
+    // Strip ANSI escape codes from compiler output to improve regex reliability
+    let re_ansi = Regex::new(r"\x1b\[[0-9;]*[mK]").unwrap();
+    let data_in = re_ansi.replace_all(&data_in, "").to_string();
 
     // Check for cargo-level errors (dependency resolution, manifest parsing, etc.)
     if data_in.contains("error: failed to") || data_in.contains("Caused by:") {


### PR DESCRIPTION
## Problem
The opaque-types build script extracts type size information by parsing Rust compiler panic messages. When the compiler outputs colored text (enabled by default in CI environments), ANSI escape codes break the regex matching, causing the build to fail with:

```
Failed to generate opaque types: there are X errors in the input data, 
but only Y of them were processed as information about opaque types
```

## Solution
Add ANSI code stripping before regex parsing using the pattern `\x1b\[[0-9;]*[mK]`, which matches standard ANSI escape sequences.

## Verification
- ✅ Reproduced the failure on macOS with `CARGO_TERM_COLOR=always`
- ✅ Confirmed the fix resolves the issue
- ✅ Build completes successfully with colored output enabled
- ✅ Backward compatible with non-colored builds